### PR TITLE
#10 [fix] deploy.sh 스크립트 수정

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
-BASE_PATH=/var/www
-BUILD_PATH=$(ls $BASE_PATH/ASAP_Server/build/libs/server-0.0.1-SNAPSHOT.jar)
+BUILD_PATH=$(ls /home/ubuntu/app/server-0.0.1-SNAPSHOT.jar)
 JAR_NAME=$(basename $BUILD_PATH)
 echo "> build 파일명: $JAR_NAME"
 


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #10 

## Key Changes 🔑
1. 내용
   - deploy.sh 스크립트 수정

## To Reviewers 📢
- CD 과정을 보면 아래와 같습니다.
``` java
1. CD yml 파일이 실행이 되면 main 브랜치에 있는 코드들 기준으로 프로젝트를 build 한 다음에
    1. build 결과로 생긴 jar 파일
    2. appspec.yml 파일
    3. scripts 내에 있는 sh 파일
이 3개를 zip 파일로 묶어서 s3로 보낸다.

2. Code Deploy는 통해서 s3에 올라간 zip 파일 중 appspec.yml 파일을 확인해서 배포를 진행한다.

3. ec2 `/home/ubuntu/app` 경로에 zip 파일 내에 있는 파일들을 전송하고, zip 파일 내에 있었던 deploy.sh를 실행한다.
```

하지만 지금까지 /build/libs/SNAPSHOT 이 경로에 있는 jar 파일을 실행 중이었기 때문에 최신 jar 파일을 실행하지 못했습니다.
그래서 build path를 수정해서 최신 jar 파일이 있는 경로를 지정해줬습니다.